### PR TITLE
fix: 뒤로가기 시 WebView 내부 뒤로가기 처리

### DIFF
--- a/.changeset/rare-items-smoke.md
+++ b/.changeset/rare-items-smoke.md
@@ -1,0 +1,5 @@
+---
+"android-sdk": patch
+---
+
+webview backpress improve

--- a/sdk/src/main/java/io/portone/sdk/android/identityverification/IdentityVerificationActivity.kt
+++ b/sdk/src/main/java/io/portone/sdk/android/identityverification/IdentityVerificationActivity.kt
@@ -3,6 +3,7 @@ package io.portone.sdk.android.identityverification
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import io.portone.sdk.android.PortOne
 import io.portone.sdk.android.PortOneWebView
@@ -23,6 +24,18 @@ class IdentityVerificationActivity : AppCompatActivity() {
                 intent.getParcelableExtra(PortOne.REQUEST)
             }
         val webView = findViewById<PortOneWebView>(R.id.web_view_identity_verification)
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (webView.canGoBack()) {
+                    webView.goBack()
+                } else {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        })
+
         if (identityVerificationRequest != null) {
             webView.requestIdentityVerification(
                 identityVerificationRequest,

--- a/sdk/src/main/java/io/portone/sdk/android/issuebillingkey/IssueBillingKeyActivity.kt
+++ b/sdk/src/main/java/io/portone/sdk/android/issuebillingkey/IssueBillingKeyActivity.kt
@@ -3,6 +3,7 @@ package io.portone.sdk.android.issuebillingkey
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import io.portone.sdk.android.PortOne
 import io.portone.sdk.android.PortOneWebView
@@ -24,6 +25,18 @@ class IssueBillingKeyActivity : AppCompatActivity() {
 
         }
         val webView = findViewById<PortOneWebView>(R.id.web_view_issue_billing_key)
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (webView.canGoBack()) {
+                    webView.goBack()
+                } else {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        })
+
         if (issueBillingKeyRequest != null) {
             webView.requestIssueBillingKey(
                 issueBillingKeyRequest,

--- a/sdk/src/main/java/io/portone/sdk/android/issuebillingkeyandpay/IssueBillingKeyAndPayActivity.kt
+++ b/sdk/src/main/java/io/portone/sdk/android/issuebillingkeyandpay/IssueBillingKeyAndPayActivity.kt
@@ -3,6 +3,7 @@ package io.portone.sdk.android.issuebillingkeyandpay
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import io.portone.sdk.android.PortOne
 import io.portone.sdk.android.PortOneWebView
@@ -23,6 +24,18 @@ class IssueBillingKeyAndPayActivity : AppCompatActivity() {
 
         }
         val webView = findViewById<PortOneWebView>(R.id.web_view_issue_billing_key_and_pay)
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (webView.canGoBack()) {
+                    webView.goBack()
+                } else {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        })
+
         if (issueBillingKeyAndPayRequest != null) {
             webView.requestIssueBillingKeyAndPay(
                 issueBillingKeyAndPayRequest,

--- a/sdk/src/main/java/io/portone/sdk/android/issuebillingkeyui/LoadIssueBillingKeyUIActivity.kt
+++ b/sdk/src/main/java/io/portone/sdk/android/issuebillingkeyui/LoadIssueBillingKeyUIActivity.kt
@@ -3,6 +3,7 @@ package io.portone.sdk.android.issuebillingkeyui
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import io.portone.sdk.android.PortOne
 import io.portone.sdk.android.PortOneWebView
@@ -25,6 +26,18 @@ class LoadIssueBillingKeyUIActivity : AppCompatActivity() {
 
         }
         val webView = findViewById<PortOneWebView>(R.id.web_view_load_issue_billing_key_ui)
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (webView.canGoBack()) {
+                    webView.goBack()
+                } else {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        })
+
         if (loadIssueBillingKeyUIRequest != null) {
             webView.loadIssueBillingKeyUI(loadIssueBillingKeyUIRequest, object :
                 IssueBillingKeyCallback {

--- a/sdk/src/main/java/io/portone/sdk/android/payment/PaymentActivity.kt
+++ b/sdk/src/main/java/io/portone/sdk/android/payment/PaymentActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import io.portone.sdk.android.PortOne
 import io.portone.sdk.android.PortOneWebView
@@ -26,6 +27,18 @@ class PaymentActivity : AppCompatActivity() {
 
         }
         val webView = findViewById<PortOneWebView>(R.id.web_view_payment)
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (webView.canGoBack()) {
+                    webView.goBack()
+                } else {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        })
+
         if (paymentRequest != null) {
             webView.requestPayment(paymentRequest, object : PaymentCallback {
                 override fun onSuccess(response: PaymentResponse) {

--- a/sdk/src/main/java/io/portone/sdk/android/paymentui/LoadPaymentUIActivity.kt
+++ b/sdk/src/main/java/io/portone/sdk/android/paymentui/LoadPaymentUIActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import io.portone.sdk.android.PortOne
 import io.portone.sdk.android.PortOneWebView
@@ -27,6 +28,18 @@ class LoadPaymentUIActivity : AppCompatActivity() {
 
         }
         val webView = findViewById<PortOneWebView>(R.id.web_view_load_payment_ui)
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (webView.canGoBack()) {
+                    webView.goBack()
+                } else {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        })
+
         if (loadPaymentUIRequest != null) {
             webView.loadPaymentUI(loadPaymentUIRequest, object : PaymentCallback {
                 override fun onSuccess(response: PaymentResponse) {


### PR DESCRIPTION
## Summary
- 결제/빌링키/본인인증 Activity에서 뒤로가기 시 Activity가 바로 종료되는 대신 WebView 내부 `goBack()` 수행
- WebView history가 없는 경우(첫 페이지)에만 Activity 종료
- 결제 진행 중 뒤로가기로 인해 결제는 성공했지만 콜백을 받지 못하는 케이스 방지

## 변경 대상 Activity (6개)
- `PaymentActivity`
- `IssueBillingKeyActivity`
- `IssueBillingKeyAndPayActivity`
- `IdentityVerificationActivity`
- `LoadPaymentUIActivity`
- `LoadIssueBillingKeyUIActivity`

## Test plan
- [ ] 결제 진행 중 뒤로가기 → WebView 내부 뒤로가기 동작 확인
- [ ] 첫 페이지에서 뒤로가기 → Activity 정상 종료 확인
- [ ] 결제 완료 후 콜백 정상 수신 확인
- [ ] 빌링키 발급 / 본인인증 플로우에서도 동일 동작 확인
- [ ] 다양한 PG사 테스트 (KCP, 이니시스, 토스페이먼츠 등)

🤖 Generated with [Claude Code](https://claude.com/claude-code)