### PR TITLE
fix: 본인인증 콜백의 onSuccess/onFail 호출부 반전되어있는 버그 수정

### DIFF
--- a/sdk/src/main/java/io/portone/sdk/android/PortOneWebView.kt
+++ b/sdk/src/main/java/io/portone/sdk/android/PortOneWebView.kt
@@ -288,9 +288,9 @@ class PortOneWebView(context: Context, attrs: AttributeSet? = null) : WebView(co
                         "portone" -> {
                             val result = handleIdentityVerificationResponse(url)
                             if (result.code == null) {
-                                identityVerificationCallback.onFail(result);
-                            } else {
                                 identityVerificationCallback.onSuccess(result);
+                            } else {
+                                identityVerificationCallback.onFail(result);
                             }
                             true
                         }


### PR DESCRIPTION
## Summary

`requestIdentityVerification`의 redirect URL 핸들러에서 `onSuccess`/`onFail` 콜백이 반전되어 있는 버그를 수정합니다.

### 현재 (버그)
```kotlin
if (result.code == null) {
    identityVerificationCallback.onFail(result)    // ← code 없음 = 성공인데 onFail 호출
} else {
    identityVerificationCallback.onSuccess(result)  // ← code 있음 = 실패인데 onSuccess 호출
}
```

### 수정 후
```kotlin
if (result.code == null) {
    identityVerificationCallback.onSuccess(result)  // ← 정상
} else {
    identityVerificationCallback.onFail(result)     // ← 정상
}
```

### 근거

1. `IdentityVerificationResponse.code`는 **"실패한 경우 오류 코드"** 로 문서화되어 있음 — `null`이면 오류 없음 = 성공
2. 같은 파일의 `requestPayment`, `requestIssueBillingKey`, `requestIssueBillingKeyAndPay`는 모두 `code == null → onSuccess`로 올바르게 구현되어 있음
3. 본인인증만 유일하게 반전됨

### 영향

이 버그로 인해 **모든 성공적인 본인인증이 `onFail(code=null, message=null)`로 보고**되어, 클라이언트에서 인증 결과를 처리할 수 없습니다.

### 원인 분석 (git blame)

| 시점 | 커밋 | 작성자 | 상태 |
|------|-------|--------|------|
| 2024-09-09 | `7fb0369` | youjmen | **최초 구현 — 정상.** `IdentityVerificationResponse.Success`/`.Fail` sealed class로 분기하여 올바르게 `onSuccess`/`onFail` 호출 |
| 2026-01-20 | `c3aeec4` | CirnoV (Sickle) | **코드젠 리팩토링 — 반전 발생.** 응답 타입을 단일 data class로 변경하면서 `code == null` 조건 분기로 전환하는 과정에서 `onSuccess`/`onFail`이 뒤바뀜 |

최초 구현 (`7fb0369`):
```kotlin
// sealed class 기반 — 정상
is IdentityVerificationResponse.Fail -> identityVerificationCallback.onFail(result)
is IdentityVerificationResponse.Success -> identityVerificationCallback.onSuccess(result)
```

코드젠 리팩토링 (`c3aeec4`) 후:
```kotlin
// code null 체크 기반 — 반전됨
if (result.code == null) {
    identityVerificationCallback.onFail(result)    // ← 반전
} else {
    identityVerificationCallback.onSuccess(result)  // ← 반전
}
```

같은 커밋에서 `requestPayment` 등 다른 메서드는 올바르게 변환되었으나, `requestIdentityVerification`만 누락된 것으로 보입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)